### PR TITLE
Updates to README for lcd_io branch

### DIFF
--- a/README.md
+++ b/README.md
@@ -196,11 +196,11 @@ Select the correct display library and display settings in following lines:
                 Editor.yPixels=240 # number of yPixels for the display
 
                 Editor.display = ST7789(display_bus, 
-                					width=Editor.xPixels, 
-                					height=Editor.yPixels, 
-                					rotation=0, 
-                					rowstart=80, 
-                					colstart=0)
+                			width=Editor.xPixels, 
+                			height=Editor.yPixels, 
+                			rotation=0, 
+                			rowstart=80, 
+                			colstart=0)
 
 ```
 

--- a/README.md
+++ b/README.md
@@ -216,10 +216,10 @@ Double-check that the settings in the `init_tty` function match your UART hardwa
 
 ```python
                 Editor.uart = busio.UART(board.TX, 
-                					board.RX, 
-                					baudrate=115200, 
-                					timeout=0.1, 
-                					receiver_buffer_size=64)
+                			board.RX, 
+                			baudrate=115200, 
+                			timeout=0.1, 
+                			receiver_buffer_size=64)
 ```
 
 

--- a/README.md
+++ b/README.md
@@ -133,6 +133,7 @@ using cpp.
 |pye2|Similar to the linemode branch, but the column does not change during vertcal moves|
 |dup_del_line|A version which allows to duplicate and delete a single line without highlighting it before (stale)|
 |new_mark|Changed method of highlighting blocks, allowing to move away the cursor once a block is highlighted (stale)|
+|lcd_io|Display output to an LCD, accepts input from UART|
 
 ## lcd_io usage
 
@@ -211,11 +212,14 @@ Update the following parameters as required for your display: `rotation=0`, `row
 ***Example:*** This example shows a 240x240 pixel display using an ST7789 display controller chip.  Because this chip can handle up to 320x240 pixel display, so to accommodate our 240x240 display size, we utilize an 80 pixel offset using the `rowstart` parameter.  Your display library is likely is different than this, and may not require any offset.
 
 ## Using UART as an input
+Double-check that the settings in the `init_tty` function match your UART hardware connections, especially for `board.TX`, `board.RX` and `baudrate`:
 
-To use UART as the input, change the following line to `True`
-
-```
-uart_input = True
+```python
+                Editor.uart = busio.UART(board.TX, 
+                					board.RX, 
+                					baudrate=115200, 
+                					timeout=0.1, 
+                					receiver_buffer_size=64)
 ```
 
 

--- a/README.md
+++ b/README.md
@@ -133,7 +133,7 @@ using cpp.
 |pye2|Similar to the linemode branch, but the column does not change during vertcal moves|
 |dup_del_line|A version which allows to duplicate and delete a single line without highlighting it before (stale)|
 |new_mark|Changed method of highlighting blocks, allowing to move away the cursor once a block is highlighted (stale)|
-|lcd_io|Display output to an LCD, accepts input from UART|
+|lcd_io|Display output to an LCD display, accepts input from UART|
 
 ## lcd_io usage
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-﻿# Micropython-Editor
+# Micropython-Editor
 
 ## Description
 
@@ -133,6 +133,91 @@ using cpp.
 |pye2|Similar to the linemode branch, but the column does not change during vertcal moves|
 |dup_del_line|A version which allows to duplicate and delete a single line without highlighting it before (stale)|
 |new_mark|Changed method of highlighting blocks, allowing to move away the cursor once a block is highlighted (stale)|
+
+## lcd_io usage
+
+This branch includes code to allow the pye editor to run on a CircuitPython board with an attached LCD display and accepting text input via UART. This version is called `pye_lcd.py`.  (Note: By using the main pye.py file, you can separately select only LCD display or only UART input by properly selecting the high level Boolean variables: `direct_lcd_io` and `uart_input`.)
+
+This branch relies on the simpleTerminal and editorTerminal class found at [https://github.com/kmatch98/simpleTerminal](https://github.com/kmatch98/simpleTerminal)
+
+To setup the display for your requirements, review and update the `init_display` function as follows:
+
+1. Update the pin connections.  
+2. Set up the SPI bus.  
+3. Select the correct display library and set the appropriate display settings.
+
+The following sections describes the steps to update the code to match your display requirements:
+
+1. Update the pin connections to match your chip's wiring.
+
+```python
+                spi = board.SPI()
+                tft_cs = board.D12 # arbitrary, pin not used for my display
+                tft_dc = board.D2
+                tft_backlight = board.D4
+                tft_reset=board.D3
+```
+
+This is the meaning of each of these four connections for the SPI bus:
+
+|Pin Name in code |Connection|
+|:---|:---| 
+|`spi`| `board.SPI()` selects clock, MOSI and MISO for this board
+|`tft_cs`|Chip Select|
+|`tft.dc`| Data/Command pin|
+|`tft_backlight`| Backlight PWM control|
+|`tft_reset`| Reset|
+
+2. Set up the SPI bus.  
+
+Edit the `displayio.FourWire` parameters to correspond to the requirements of your display.  For example set the `baudrate`, `polarity`, and `phase` to correspond to the requirements of your display.
+
+```python
+                display_bus = displayio.FourWire(
+                    spi,
+                    command=tft_dc,
+                    chip_select=tft_cs,
+                    reset=tft_reset,
+                    baudrate=24000000,
+                    polarity=1,
+                    phase=1,
+                )
+```
+***Example:*** In this example, this display uses SPI\_Mode3, requiring `polarity=1` and `phase=1`.  
+If using a display requiring SPI_Mode1, then set `polarity=0` and `phase=1`.  More details can be found in this [SPI mode table on Wikipedia] (https://en.wikipedia.org/wiki/Serial_Peripheral_Interface#Mode_numbers).
+
+3. Select the correct display library and set the appropriate display settings.
+
+Select the correct display library and display settings in following lines:
+
+```python
+                Editor.xPixels=240 # number of xPixels for the display
+                Editor.yPixels=240 # number of yPixels for the display
+
+                Editor.display = ST7789(display_bus, 
+                					width=Editor.xPixels, 
+                					height=Editor.yPixels, 
+                					rotation=0, 
+                					rowstart=80, 
+                					colstart=0)
+
+```
+
+Edit the `Editor.xPixels=240` and `Editor.yPixels=240` to correspond to the pixel dimensions of your display.
+
+Update the following parameters as required for your display: `rotation=0`, `rowstart=80` and `colstart=0`.
+
+
+***Example:*** This example shows a 240x240 pixel display using an ST7789 display controller chip.  Because this chip can handle up to 320x240 pixel display, so to accommodate our 240x240 display size, we utilize an 80 pixel offset using the `rowstart` parameter.  Your display library is likely is different than this, and may not require any offset.
+
+## Using UART as an input
+
+To use UART as the input, change the following line to `True`
+
+```
+uart_input = True
+```
+
 
 ## Short Version History
 


### PR DESCRIPTION
I updated the README to provide guidance on how to use the lcd_io branch with an external LCD display and UART input.  Here are the main things to know:

1.  Update the pin definitions for the SPI display
2.  Setup the SPI bus.  **Notice:** Make sure the polarity and phase setting to match your display's SPI_mode.
3.  Select the right display library to match your LCD display driver.

