### PR TITLE
Update rd to account for ItsyBitsy NRF52840 which returns a blank str…

### DIFF
--- a/pye_lcd.py
+++ b/pye_lcd.py
@@ -62,7 +62,8 @@ class IO_DEVICE:
     def rd(self):
         while True:
             myInput = self.uart.read(1) # for using uart
-            if myInput is None:
+            if (myInput is None) or (myInput.decode('utf-8') == ''): 
+		# for some reason, ItsyBitsy NRF52840 needs second Boolean check
                 pass
             else:
                 return myInput.decode('utf-8')


### PR DESCRIPTION
…ing when no input on UART

The original code was developed on an Adafruit ItsyBitsy M4.  I am also now using an Adafruit ItsyBitsy NRF52840 and for some reason `uart.read(1)` returns an empty string on this board, rather than `None`.  

In addition to the existing `myInput is None` check, I added one additional Boolean to check for a blank string.  I verified that this works on the following hardware:
- ItsyBitsy M4 Express
- ItsyBitsy NRF52840